### PR TITLE
Update MINI JCW generations: Added Wikipedia references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
-# Model make
+# MINI JCW
+
+This repository contains signal set configurations for the MINI JCW, organized by model year and version. The files are structured to allow for easy differentiation between model generations and other vehicle parameters, ensuring accurate signal mapping for each version of the MINI JCW.
+
+## Contributing
+
+Contributions are welcome! If you would like to add support for additional model years or other configurations, please open an issue or submit a pull request.
+
+1. Fork the repository
+2. Create a new branch for your changes
+3. Commit your changes and open a pull request with a detailed description
+
+## Issues
+
+If you encounter any issues or would like to discuss improvements, please feel free to open an issue. We encourage collaboration and appreciate feedback to make the repository as accurate and useful as possible.
 

--- a/generations.yaml
+++ b/generations.yaml
@@ -1,3 +1,7 @@
+references:
+  - "https://en.wikipedia.org/wiki/John_Cooper_Works"
+  - "https://en.wikipedia.org/wiki/Mini_Hatch"
+
 generations:
   - name: "First Generation (R53)"
     start_year: 2002


### PR DESCRIPTION
- Added references array with John Cooper Works and Mini Hatch Wikipedia articles
- Updated README.md with standard template
- Generation data verified against Wikipedia sources
